### PR TITLE
create group with id $gid (if it doesn't exist yet... or if it does, we don't care, I think)

### DIFF
--- a/run
+++ b/run
@@ -22,6 +22,7 @@ for users in "$@"; do
 
     if [ -n "$gid" ]; then
         useraddParams="$useraddParams -g $gid"
+	groupadd -g $gid $gid
     fi
 
     useradd $useraddParams "$user"


### PR DESCRIPTION
Hi! I found your code useful but the one issue I had was that the gid mapping wasn't working and so I added that one line of (bash) code and now this image works for me! Pull it in if that's something you deem useful!
What it does is simply create a group with name and gid of $gid and I suppose that it doesn't crash the whole ./run script if the group already exists, but I haven't checked that.
Cheers
