### PR TITLE
Enable logging via rsyslog and supervisord.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,14 @@ FROM debian:jessie
 MAINTAINER Adrian Dvergsdal [atmoz.net]
 
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get -y install openssh-server && \
+    DEBIAN_FRONTEND=noninteractive apt-get -y install openssh-server rsyslog supervisor && \
     rm -rf /var/lib/apt/lists/*
 
 # sshd needs this directory to run
 RUN mkdir -p /var/run/sshd
 
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+COPY sshd.conf /etc/rsyslog.d/sshd.conf
 COPY sshd_config /etc/ssh/sshd_config
 COPY entrypoint /
 COPY README.md /

--- a/entrypoint
+++ b/entrypoint
@@ -58,6 +58,13 @@ function createUser() {
     chown root:root /home/$user
     chmod 755 /home/$user
 
+    # Added to enable logging
+    mkdir /home/$user/dev
+    chmod 755 /home/$user/dev
+    /etc/init.d/rsyslog start # create the socket
+    ln -f /home/sftp.log.socket /home/$user/dev/log
+    touch /var/log/sftp.log
+
     if [ -z "$pass" ]; then
         pass="$(echo `</dev/urandom tr -dc A-Za-z0-9 | head -c256`)"
         chpasswdOptions=""
@@ -124,4 +131,4 @@ if [ ! -f "$userConfFinalPath" ]; then
     fi
 fi
 
-exec /usr/sbin/sshd -D
+exec /usr/bin/supervisord

--- a/sshd.conf
+++ b/sshd.conf
@@ -1,0 +1,5 @@
+# Create an additional socket for some of the sshd chrooted users.
+$AddUnixListenSocket /home/sftp.log.socket
+# Log internal-sftp in a separate file
+:programname, isequal, "internal-sftp" -/var/log/sftp.log
+:programname, isequal, "internal-sftp" ~

--- a/sshd_config
+++ b/sshd_config
@@ -4,4 +4,4 @@ Subsystem sftp internal-sftp
 ChrootDirectory %h
 X11Forwarding no
 AllowTcpForwarding no
-ForceCommand internal-sftp
+ForceCommand internal-sftp -l VERBOSE

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,0 +1,16 @@
+[supervisord]
+nodaemon=true
+
+[program:sshd]
+command=/usr/sbin/sshd -D
+redirect_stderr=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+autorestart=true
+
+[program:logger]
+command=tail -f /var/log/sftp.log
+redirect_stderr=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+autorestart=true


### PR DESCRIPTION
* [x] Adds rsyslog and supervisord packages
* [x] Runs syslog service and creates a link to the logging socket in the chroot user's home dir.
* [x] Logs locally in the container to /var/log/sftp.log
* [x] Supervisord ensures that sshd runs as well as a 'logger' process which simply tails /var/log/sftp.log and sends to STDOUT.