### PR TITLE
run /etc/sftp.d script each time (even after restarts)

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -114,8 +114,6 @@ if [ ! -f "$userConfFinalPath" ]; then
     while IFS= read -r user || [[ -n "$user" ]]; do
         createUser "$user"
     done < "$userConfFinalPath"
-
-   
 fi
 # Source custom scripts, if any
 if [ -d /etc/sftp.d ]; then

--- a/entrypoint
+++ b/entrypoint
@@ -115,13 +115,13 @@ if [ ! -f "$userConfFinalPath" ]; then
         createUser "$user"
     done < "$userConfFinalPath"
 
-    # Source custom scripts, if any
-    if [ -d /etc/sftp.d ]; then
-        for f in /etc/sftp.d/*; do
-            [ -x "$f" ] && . "$f"
-        done
-        unset f
-    fi
+   
 fi
-
+# Source custom scripts, if any
+if [ -d /etc/sftp.d ]; then
+    for f in /etc/sftp.d/*; do
+        [ -x "$f" ] && . "$f"
+    done
+    unset f
+fi
 exec /usr/sbin/sshd -D


### PR DESCRIPTION
If we have a directory to mount and if we run only the first time the scripts the directory won't be mounted after restarts. The PR fixes the issue.