### PR TITLE
Add default directories creation to user configuration 

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Examples
 docker run \
     -v /host/share:/home/foo/share \
     -p 2222:22 -d atmoz/sftp \
-    foo:123:1001
+    foo:123:1001;share
 ```
 
 #### Using Docker Compose:

--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ Easy to use SFTP ([SSH File Transfer Protocol](https://en.wikipedia.org/wiki/SSH
 Usage
 -----
 
-- Define users as command arguments, STDIN or mounted in /etc/sftp-users.conf
-  (syntax: `user:pass[:e][:uid[:gid]]...`).
+- Define users as command arguments, STDIN or mounted in `/etc/sftp-users.conf`
+  (syntax: `user:pass[:e][:uid[:gid]][;folder1:folder2]`).
   - You must set custom UID for your users if you want them to make changes to
     your mounted volumes with permissions matching your host filesystem.
+  - You can create folders within user's home directory for which user will be owner and will be able to write/upload.
 - Mount volumes in user's home folder.
   - The users are chrooted to their home directory, so you must mount the
     volumes in separate directories inside the user's home directory
@@ -36,7 +37,7 @@ sftp:
         - /host/share:/home/foo/share
     ports:
         - "2222:22"
-    command: foo:123:1001
+    command: foo:123:1001;share
 ```
 
 #### Logging in
@@ -59,8 +60,8 @@ docker run \
 /host/users.conf:
 
 ```
-foo:123:1001
-bar:abc:1002
+foo:123:1001;share:documents
+bar:abc:1002;http
 ```
 
 ### Encrypted password
@@ -71,10 +72,10 @@ Add `:e` behind password to mark it as encrypted. Use single quotes if using ter
 docker run \
     -v /host/share:/home/foo/share \
     -p 2222:22 -d atmoz/sftp \
-    'foo:$1$0G2g0GSt$ewU0t6GXG15.0hWoOX8X9.:e:1001'
+    'foo:$1$0G2g0GSt$ewU0t6GXG15.0hWoOX8X9.:e:1001;share'
 ```
 
-Tip: you can use makepasswd to generate encrypted passwords:  
+Tip: you can use `makepasswd` to generate encrypted passwords:  
 `echo -n "password" | makepasswd --crypt-md5 --clearfrom -`
 
 ### Using SSH key (without password)
@@ -88,18 +89,18 @@ docker run \
     -v /host/id_other.pub:/home/foo/.ssh/keys/id_other.pub:ro \
     -v /host/share:/home/foo/share \
     -p 2222:22 -d atmoz/sftp \
-    foo::1001
+    foo::1001;share
 ```
 
 ### Execute custom scripts or applications
 
-Put your programs in /etc/sftp.d/ and it will automatically run when the container starts.
+Put your programs in `/etc/sftp.d/` and it will automatically run when the container starts.
 See next section for an example.
 
 ### Bindmount dirs from another location
 
-If you are using --volumes-from or just want to make a custom directory
-available in user's home directory, you can add a script to /etc/sftp.d/ that
+If you are using `--volumes-from` or just want to make a custom directory
+available in user's home directory, you can add a script to `/etc/sftp.d/` that
 bindmounts after container starts.
 
 ```

--- a/entrypoint
+++ b/entrypoint
@@ -17,18 +17,26 @@ function printReadme() {
 }
 
 function createUser() {
-    IFS=':' read -a param <<< $@
-    user="${param[0]}"
-    pass="${param[1]}"
+    # user:pass[:e][:uid[:gid]][;folder1:folder2]
 
-    if [ "${param[2]}" == "e" ]; then
-        chpasswdOptions="-e"
-        uid="${param[3]}"
-        gid="${param[4]}"
-    else
-        uid="${param[2]}"
-        gid="${param[3]}"
-    fi
+    while IFS=';' read -ra part; do
+        userInfos="${part[0]}"
+        folders="${part[1]}"
+    done <<< $@
+
+    while IFS=':' read -ra param; do
+        user="${param[0]}"
+        pass="${param[1]}"
+
+        if [ "${param[2]}" == "e" ]; then
+            chpasswdOptions="-e"
+            uid="${param[3]}"
+            gid="${param[4]}"
+        else
+            uid="${param[2]}"
+            gid="${param[3]}"
+        fi
+    done <<< $userInfos
 
     if [ -z "$user" ]; then
         echo "FATAL: You must at least provide a username."
@@ -65,6 +73,14 @@ function createUser() {
     fi
 
     echo "$user:$pass" | chpasswd $chpasswdOptions
+
+    # create folders & configure permissions
+    while IFS=':' read -ra part; do
+        for folder in "${part[@]}"; do
+            mkdir -p /home/$user/$folder
+            chown -R $user:users /home/$user/$folder
+        done
+    done <<< $folders
 
     # Add SSH keys to authorized_keys with valid permissions
     if [ -d /home/$user/.ssh/keys ]; then


### PR DESCRIPTION
Add parameters to user configuration to support creation of directories within user's home:
`user:pass[:e][:uid[:gid]][;folder1:folder2]`

User will be owner of these folders.

I've also updated the way `IFS` was used so we don't redefined it for the whole shell env, but just within our loops.

I think, this could fix https://github.com/atmoz/sftp/issues/16, https://github.com/atmoz/sftp/issues/37 and other permissions related issues... 