### PR TITLE
Fix chown commands on alpine for user names with a dot

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -61,6 +61,10 @@ function createUser() {
     chown root:root /home/$user
     chmod 755 /home/$user
 
+    # Retrieving user id to use it in chown commands instead of the user name
+    # to avoid problems on alpine when the user name contains a '.'
+    uid=`id $user -u`
+
     if [ -n "$pass" ]; then
         echo "$user:$pass" | chpasswd $chpasswdOptions
     else
@@ -70,7 +74,7 @@ function createUser() {
     # Add SSH keys to authorized_keys with valid permissions
     if [ -d /home/$user/.ssh/keys ]; then
         cat /home/$user/.ssh/keys/* >> /home/$user/.ssh/authorized_keys
-        chown $user /home/$user/.ssh/authorized_keys
+        chown $uid /home/$user/.ssh/authorized_keys
         chmod 600 /home/$user/.ssh/authorized_keys
     fi
 
@@ -81,7 +85,7 @@ function createUser() {
             dirPath=/home/$user/$dirPath
             echo "Creating and/or setting permissions on $dirPath"
             mkdir -p $dirPath
-            chown -R $user:users $dirPath
+            chown -R $uid:users $dirPath
         done
     fi
 }


### PR DESCRIPTION
Hey there,

If I try to run the sftp server with a user name that has a dot in it (e.g `foo.bar`), everything works fine for the debian image, but not for the alpine image :

```
# docker run -p 22:22 -it atmoz/sftp:alpine foo.bar:pass:::upload

Creating mailbox file: No such file or directory
Creating and/or setting permissions on /home/foo.bar/upload
chown: unknown user/group foo:bar:users
```

The problem is in the chown commands:
```
chown $user /home/$user/.ssh/authorized_keys
```

Under alpine, the chown command looks for either a `.` or `:` separator to separate user and group. I haven't seen any way to escape that special character, but you can use the same chown command and replace the user name by the user id.

```
uid=`id $user -u`
chown $uid /home/$user/.ssh/authorized_keys
```

This PR fixes the alpine version and doesn't change the behavior of the debian version.