### PR TITLE
Group name the same as the User

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -51,7 +51,7 @@ function createUser() {
 
     if [ -n "$gid" ]; then
         if ! $(cat /etc/group | cut -d: -f3 | grep -q "$gid"); then
-            groupadd --gid $gid "group_$gid"
+            groupadd --gid $gid "$user"
         fi
 
         useraddOptions="$useraddOptions --gid $gid"


### PR DESCRIPTION
It would be more nix-like to set the group name the same as user when creating it.