### PR TITLE
update readme with correct path for conf file

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This is an automated build linked with the [debian](https://hub.docker.com/_/deb
 
 # Usage
 
-- Required: define users as command arguments, STDIN or mounted in `/etc/sftp/users.conf`
+- Required: define users as command arguments, STDIN or mounted in `/etc/sftp-users.conf`
   (syntax: `user:pass[:e][:uid[:gid[:dir1[,dir2]...]]]...`).
   - Set UID/GID manually for your users if you want them to make changes to
     your mounted volumes with permissions matching your host filesystem.
@@ -80,7 +80,7 @@ OpenSSH client, run: `sftp -P 2222 foo@<host-ip>`
 
 ```
 docker run \
-    -v /host/users.conf:/etc/sftp/users.conf:ro \
+    -v /host/users.conf:/etc/sftp-users.conf:ro \
     -v mySftpVolume:/home \
     -v /host/ssh_host_rsa_key:/etc/ssh/ssh_host_rsa_key \
     -v /host/ssh_host_rsa_key.pub:/etc/ssh/ssh_host_rsa_key.pub \


### PR DESCRIPTION
I had issue with docker-compose and docker when using volumes. It seems the path to add user.conf is not /etc/sftp/users.conf but /etc/sftp-users.conf.

Tested with docker-compose and docker alone.
