### PR TITLE
Make sure to reset chpasswdOptions.

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -45,6 +45,8 @@ function createUser() {
     if [ "${args[2]}" == "e" ]; then
         chpasswdOptions="-e"
         index=1
+    else
+        chpasswdOptions=""
     fi
 
     uid="${args[$[$index+2]]}"; validateArg "UID" "$uid" "$reUid" || return 1


### PR DESCRIPTION
I noticed that the flag wasn't getting reset across calls to createUser.

Was using this in kubernetes on the latest branch. This fixes my issue, I think before the `-e` flag was being sent in for clear passwords (I had a couple of encrypted passwords followed by a couple of unencrypted passwords in my configuration).

Thanks for the great project, was super easy to setup!