### PR TITLE
Adding watch and permission update scripts.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Adrian Dvergsdal [atmoz.net]
 # - OpenSSH needs /var/run/sshd to run
 # - Remove generic host keys, entrypoint generates unique keys
 RUN apt-get update && \
-    apt-get -y install openssh-server && \
+    apt-get -y install openssh-server inotify-tools && \
     rm -rf /var/lib/apt/lists/* && \
     mkdir -p /var/run/sshd && \
     rm -f /etc/ssh/ssh_host_*key*
@@ -13,6 +13,7 @@ RUN apt-get update && \
 COPY sshd_config /etc/ssh/sshd_config
 COPY entrypoint /
 COPY README.md /
+COPY watch.sh /
 
 EXPOSE 22
 

--- a/entrypoint
+++ b/entrypoint
@@ -88,6 +88,17 @@ function createUser() {
     fi
 }
 
+function startWatch() {
+
+	if [ -n "$WATCH" ]; then
+		/watch.sh \
+			--owner "$WATCH_OWNER" \
+			--group "$WATCH_GROUP" \
+			--permission "$WATCH_PERMISSION" \
+			"$WATCH_TARGET" &
+	fi
+}
+
 if [[ $1 =~ ^--help$|^-h$ ]]; then
     printHelp
     exit 0
@@ -150,4 +161,5 @@ if [ -d /etc/sftp.d ]; then
     unset f
 fi
 
+startWatch
 exec /usr/sbin/sshd -D -e

--- a/entrypoint
+++ b/entrypoint
@@ -5,6 +5,8 @@ export DEBIAN_FRONTEND=noninteractive
 userConfPath="/etc/sftp-users.conf"
 userConfFinalPath="/var/run/sftp-users.conf"
 
+chmod +x /etc/sftp.d/*.sh
+
 function printHelp() {
     echo "Add users as command arguments, STDIN or mounted in $userConfPath"
     echo "Syntax: user:pass[:e][:uid[:gid[:dir1[,dir2]...]]] ..."

--- a/watch.sh
+++ b/watch.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+arg=
+owner=
+group=
+permission=
+target=
+instructions=
+
+while [ $# -gt 0 ]; do
+	arg="$1"; shift
+	case "$arg" in
+		--owner) owner="$1"; shift ;;
+		--group) group="$1"; shift ;;
+		--permission) permission="$1"; shift ;;
+		*) target="$arg" ;;
+	esac
+done
+
+if [ -n "$target" ]; then
+	if [ ! -f "$target" -a ! -d "$target" ]; then
+		echo "Target $target is not a file or directory."
+		return
+	fi
+fi
+
+[ -z "$owner" ] && owner="$(whoami)"
+[ -z "$group" ] && group="$(groups | awk '{ print $1 }')"
+[ -z "$permission" ] && permission='0755'
+
+inotifywait -mrq -e create "$target" | \
+	while read path action file; do \
+		chmod "$permission" "$path$file"
+		chown "$owner:$group" "$path$file"
+	done


### PR DESCRIPTION
This imbues this image with the ability to actively watch the file system based on a configurable target, and `chmod`/`chown` any files therein. Currently this only works for freshly-created files, but it can be opened up to more types.

Under the hood, this uses the inotify-tools suite and a bit of Bash.

To get the watcher to work, you must set a few environment variables:

- **WATCH**: enable watching.
- **WATCH_TARGET**: the directory to watch for file creation.
- **WATCH_OWNER**: the new owner for all created files. Defaults to _$(whoami)_.
- **WATCH_GROUP**: the new group for all created files. Defaults to _$(groups | awk '{ print $1 }')_.
- **WATCH_PERMISSION**: the new permission level for all files files. Defaults to 0755.

To handle Smitty's particular problem, we would add the following environment variables to the Kubernetes deployment:

```
"env": [
   ...
   {
      "name": "WATCH",
      "value": "true"
   },
   {
      "name": "WATCH_TARGET",
      "value": "/data"
   },
   {
      "name": "WATCH_OWNER",
      "value": "www-data"
   },
   {
      "name": "WATCH_GROUP",
      "value": "www-data"
   },
   {
      "name": "WATCH_PERMISSION",
      "value": "0755"
   }
   ...
]
```