### PR TITLE
Added check to get users from a Docker secret

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -148,6 +148,15 @@ if [ ! -f "$userConfFinalPath" ]; then
         done
     fi
 
+    if [ -n "$DOCKER_SECRET" ]; then
+        #Append users from Docker secret to final config
+        secret=$(cat "/run/secrets/$DOCKER_SECRET")
+        for user in $secret
+        do
+            echo "$user" >> "$userConfFinalPath"
+        done
+    fi
+
     # Check that we have users in config
     if [[ -f "$userConfFinalPath" && "$(cat "$userConfFinalPath" | wc -l)" > 0 ]]; then
         # Import users from final conf file


### PR DESCRIPTION
I added a extra check that allows for adding users that are defined in a docker secret. 

You can then define a secret like: 
`printf user:pass:UID:GID:DIR | docker secret create my-secret`

And point your service to the secret.  The secrets name is passed in with a environment variable. 
```
services:
  sftp:
    image: atmoz:latest
    secrets:
      - my-secret
    environment:
      - DOCKER_SECRET=my-secret
secrets:
  my-secret:
    external: true
```