### PR TITLE
Hot update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,14 @@ MAINTAINER Adrian Dvergsdal [atmoz.net]
 # - OpenSSH needs /var/run/sshd to run
 # - Remove generic host keys, entrypoint generates unique keys
 RUN apt-get update && \
-    apt-get -y install openssh-server supervisor && \
+    apt-get -y install openssh-server supervisor inotify-tools && \
     rm -rf /var/lib/apt/lists/* && \
     mkdir -p /var/run/sshd && \
     rm -f /etc/ssh/ssh_host_*key*
 
 COPY sshd_config /etc/ssh/sshd_config
 COPY entrypoint /
-
+COPY supervisord.conf /etc/supervisor/supervisord.conf
 EXPOSE 22
 
 ENTRYPOINT ["/usr/bin/supervisord"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER Adrian Dvergsdal [atmoz.net]
 # - OpenSSH needs /var/run/sshd to run
 # - Remove generic host keys, entrypoint generates unique keys
 RUN apt-get update && \
-    apt-get -y install openssh-server && \
+    apt-get -y install openssh-server supervisor && \
     rm -rf /var/lib/apt/lists/* && \
     mkdir -p /var/run/sshd && \
     rm -f /etc/ssh/ssh_host_*key*
@@ -16,4 +16,5 @@ COPY entrypoint /
 
 EXPOSE 22
 
-ENTRYPOINT ["/entrypoint"]
+ENTRYPOINT ["/usr/bin/supervisord"]
+

--- a/entrypoint
+++ b/entrypoint
@@ -181,10 +181,10 @@ if [ -d /etc/sftp.d ]; then
     unset f
 fi
 
-if $startSshd; then
-    log "Executing sshd"
-    exec /usr/sbin/sshd -D -e
-else
-    log "Executing $@"
-    exec "$@"
-fi
+#if $startSshd; then
+#    log "Executing sshd"
+#    exec /usr/sbin/sshd -D -e
+#else
+#    log "Executing $@"
+#    exec "$@"
+#fi

--- a/entrypoint
+++ b/entrypoint
@@ -55,26 +55,25 @@ function createUser() {
     dir="${args[$[$skipIndex+4]]}"; validateArg "dirs" "$dir" "$reDir" || return 1
 
     if getent passwd $user > /dev/null; then
-        log "WARNING: User \"$user\" already exists. Skipping."
-        return 0
+        log "WARNING: User \"$user\" already exists. Skipping creation."
+    else
+	if [ -n "$uid" ]; then
+	    useraddOptions="$useraddOptions --non-unique --uid $uid"
+	fi
+
+	if [ -n "$gid" ]; then
+	    if ! getent group $gid > /dev/null; then
+	        groupadd --gid $gid "group_$gid"
+            fi
+
+	    useraddOptions="$useraddOptions --gid $gid"
+	fi
+
+	useradd $useraddOptions $user
+	mkdir -p /home/$user
+	chown root:root /home/$user
+	chmod 755 /home/$user
     fi
-
-    if [ -n "$uid" ]; then
-        useraddOptions="$useraddOptions --non-unique --uid $uid"
-    fi
-
-    if [ -n "$gid" ]; then
-        if ! getent group $gid > /dev/null; then
-            groupadd --gid $gid "group_$gid"
-        fi
-
-        useraddOptions="$useraddOptions --gid $gid"
-    fi
-
-    useradd $useraddOptions $user
-    mkdir -p /home/$user
-    chown root:root /home/$user
-    chmod 755 /home/$user
 
     # Retrieving user id to use it in chown commands instead of the user name
     # to avoid problems on alpine when the user name contains a '.'
@@ -111,19 +110,7 @@ function createUser() {
     fi
 }
 
-# Allow running other programs, e.g. bash
-if [[ -z "$1" || "$1" =~ $reArgsMaybe ]]; then
-    startSshd=true
-else
-    startSshd=false
-fi
-
-# Backward compatibility with legacy config path
-if [ ! -f "$userConfPath" -a -f "$userConfPathLegacy" ]; then
-    mkdir -p "$(dirname $userConfPath)"
-    ln -s "$userConfPathLegacy" "$userConfPath"
-fi
-
+function main() {
 # Create users only on first run
 if [ ! -f "$userConfFinalPath" ]; then
     mkdir -p "$(dirname $userConfFinalPath)"
@@ -166,6 +153,7 @@ if [ ! -f "$userConfFinalPath" ]; then
     if [ ! -f /etc/ssh/ssh_host_rsa_key ]; then
         ssh-keygen -t rsa -b 4096 -f /etc/ssh/ssh_host_rsa_key -N ''
     fi
+    rm $userConfFinalPath
 fi
 
 # Source custom scripts, if any
@@ -180,11 +168,17 @@ if [ -d /etc/sftp.d ]; then
     done
     unset f
 fi
+}
 
-#if $startSshd; then
-#    log "Executing sshd"
-#    exec /usr/sbin/sshd -D -e
-#else
-#    log "Executing $@"
-#    exec "$@"
-#fi
+# Backward compatibility with legacy config path
+if [ ! -f "$userConfPath" -a -f "$userConfPathLegacy" ]; then
+    mkdir -p "$(dirname $userConfPath)"
+    ln -s "$userConfPathLegacy" "$userConfPath"
+fi
+
+main
+inotifywait -m -e modify $userConfPath |
+while read events; do
+    main
+done
+

--- a/sshd_config
+++ b/sshd_config
@@ -14,7 +14,7 @@ X11Forwarding no
 AllowTcpForwarding no
 
 # Force sftp and chroot jail
-Subsystem sftp internal-sftp
+Subsystem sftp internal-sftp -f AUTH -l INFO
 ForceCommand internal-sftp
 ChrootDirectory %h
 

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -3,7 +3,11 @@ nodaemon=true
 
 [program:entry]
 command=/entrypoint
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 
 [program:sshd]
 command=/usr/sbin/sshd -D -e
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,0 +1,9 @@
+[supervisord]
+nodaemon=true
+
+[program:entry]
+command=/entrypoint
+
+[program:sshd]
+command=/usr/sbin/sshd -D -e
+


### PR DESCRIPTION
Closes #133.
This PR aims to deliver hot-update for the SFTP user config. The target is to handle new users and password changes. Other modifications (such as uid change or user deletion) in the user config is out of scope now. Users.conf is watched for changes with inotifywait. This may happen in another container, which also accessing the same config as a mount.
Jobs done:
- [x] Supervisor integrated.
- [x] Entrypoint is a standalone, watcher daemon, triggers the original function when users.conf changes. Managed by supervisord.
- [x] Sshd also became a standalone daemon, managed with supervisord.
- [ ] Cleaning up, renaming, refactoring.
