### PR TITLE
Allow users.conf/command-argument specified user-dirs to contain spaces

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -98,12 +98,12 @@ function createUser() {
     # Make sure dirs exists
     if [ -n "$dir" ]; then
         IFS=',' read -a dirArgs <<< $dir
-        for dirPath in ${dirArgs[@]}; do
+        for dirPath in "${dirArgs[@]}"; do
             dirPath="/home/$user/$dirPath"
             if [ ! -d "$dirPath" ]; then
                 log "Creating directory: $dirPath"
-                mkdir -p $dirPath
-                chown -R $uid:users $dirPath
+                mkdir -p "$dirPath"
+                chown -R $uid:users "$dirPath"
             else
                 log "Directory already exists: $dirPath"
             fi

--- a/tests/run
+++ b/tests/run
@@ -43,7 +43,7 @@ function beforeTest() {
     rm -rf "$tmpDir" # clean state
     mkdir "$tmpDir"
 
-    echo "test::$(id -u):$(id -g):dir1,dir2" >> "$tmpDir/users"
+    echo "test::$(id -u):$(id -g):dir1,dir 2" >> "$tmpDir/users"
     echo "" >> "$tmpDir/users" # empty line
     echo "# comments are allowed" >> "$tmpDir/users"
     echo "  " >> "$tmpDir/users" # only whitespace
@@ -172,7 +172,7 @@ function testDir() {
         "cd dir1" \
         "mkdir test-dir1" \
         "get -rf test-dir1 $tmpDir/" \
-        "cd ../dir2" \
+        "cd '../dir 2'" \
         "mkdir test-dir2" \
         "get -rf test-dir2 $tmpDir/" \
         "exit"


### PR DESCRIPTION
Fixes #138

N.B. I couldn't see a simple way to handle users passed in the `SFTP_USERS` env var as it is split into individual users on IFS (so, spaces) [here](https://github.com/atmoz/sftp/blob/844bcb44096f5c10ebfa5bec458d6f7a24769a78/entrypoint#L145) - an approach that is [likely unsafe in general](https://stackoverflow.com/questions/10586153/split-string-into-an-array-in-bash#comment42141092_15400047) but I didn't want to alter it for backwards-compatability