### PR TITLE
Switched to Debian stretch Slim version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM debian:stretch
+ARG DEBIAN_VERSION=stretch-slim
+
+FROM debian:${DEBIAN_VERSION}
 MAINTAINER Adrian Dvergsdal [atmoz.net]
 
 # Steps done in one RUN layer:


### PR DESCRIPTION
This appears to work without problem and reduces the image size by 52MB.