### PR TITLE
Fix 'return' statement usage in shell scripts

### DIFF
--- a/files/create-sftp-user
+++ b/files/create-sftp-user
@@ -36,21 +36,21 @@ skipIndex=0
 chpasswdOptions=""
 useraddOptions=(--no-user-group)
 
-user="${args[0]}"; validateArg "username" "$user" "$reUser" || return 1
-pass="${args[1]}"; validateArg "password" "$pass" "$rePass" || return 1
+user="${args[0]}"; validateArg "username" "$user" "$reUser" || exit 1
+pass="${args[1]}"; validateArg "password" "$pass" "$rePass" || exit 1
 
 if [ "${args[2]}" == "e" ]; then
     chpasswdOptions="-e"
     skipIndex=1
 fi
 
-uid="${args[$((skipIndex+2))]}"; validateArg "UID" "$uid" "$reUid" || return 1
-gid="${args[$((skipIndex+3))]}"; validateArg "GID" "$gid" "$reGid" || return 1
-dir="${args[$((skipIndex+4))]}"; validateArg "dirs" "$dir" "$reDir" || return 1
+uid="${args[$((skipIndex+2))]}"; validateArg "UID" "$uid" "$reUid" || exit 1
+gid="${args[$((skipIndex+3))]}"; validateArg "GID" "$gid" "$reGid" || exit 1
+dir="${args[$((skipIndex+4))]}"; validateArg "dirs" "$dir" "$reDir" || exit 1
 
 if getent passwd "$user" > /dev/null; then
     log "WARNING: User \"$user\" already exists. Skipping."
-    return 0
+    exit 0
 fi
 
 if [ -n "$uid" ]; then


### PR DESCRIPTION
In my workloads I've started to receive the following error recently:
```
/usr/local/bin/create-sftp-user: line 53: return: can only `return' from a function or sourced script
/usr/local/bin/create-sftp-user: Error on line 53: return 0
```

I'm using `alpine` version.

As error shows the bad thing happens [here](https://github.com/atmoz/sftp/blob/67e73dfd9ad2d1cfd93706adce425cba86f14425/files/create-sftp-user#L53), and it seems that the following usage of `return` is not tolerated by Alpine's shell.

I've changed `return` outside functions to `exit` to avoid this error.