### PR TITLE
Fix chroot users so that users have the ability to upload files direc…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && \
     apt-get -y install openssh-server && \
     rm -rf /var/lib/apt/lists/* && \
     mkdir -p /var/run/sshd && \
+    mkdir /chroot && \
     rm -f /etc/ssh/ssh_host_*key*
 
 COPY files/sshd_config /etc/ssh/sshd_config

--- a/files/create-sftp-user
+++ b/files/create-sftp-user
@@ -66,9 +66,13 @@ if [ -n "$gid" ]; then
 fi
 
 useradd "${useraddOptions[@]}" "$user"
-mkdir -p "/home/$user"
-chown root:root "/home/$user"
-chmod 755 "/home/$user"
+mkdir -p "/chroot/home/$user"
+chown "$user:users" "/chroot/home/$user"
+chmod 700 "/chroot/home/$user"
+
+# Symlink the user's chroot home dir back to the os default location
+# this is required to ensure the sshd can locate the ".ssh/authorized_keys" file
+ln -s "/chroot/home/$user" "/home/$user"
 
 # Retrieving user id to use it in chown commands instead of the user name
 # to avoid problems on alpine when the user name contains a '.'
@@ -93,7 +97,7 @@ fi
 if [ -n "$dir" ]; then
     IFS=',' read -ra dirArgs <<< "$dir"
     for dirPath in "${dirArgs[@]}"; do
-        dirPath="/home/$user/$dirPath"
+        dirPath="/chroot/home/$user/$dirPath"
         if [ ! -d "$dirPath" ]; then
             log "Creating directory: $dirPath"
             mkdir -p "$dirPath"

--- a/files/sshd_config
+++ b/files/sshd_config
@@ -16,7 +16,7 @@ AllowTcpForwarding no
 # Force sftp and chroot jail
 Subsystem sftp internal-sftp
 ForceCommand internal-sftp
-ChrootDirectory %h
+ChrootDirectory /chroot
 
 # Enable this for more logs
 #LogLevel VERBOSE


### PR DESCRIPTION
…tly into their home directory

* Move users home directories into `/chroot`
* Update sshd_config 
* Update supporting scripts
* SFTP sessions start with CWD `/home/<user>`
* Tighter home directory perms prevent unwanted access by other users.

Users will now be able to upload files and create directories in their home directory via SFTP.