### PR TITLE
Reload user creation when users.conf changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER Adrian Dvergsdal [atmoz.net]
 # - OpenSSH needs /var/run/sshd to run
 # - Remove generic host keys, entrypoint generates unique keys
 RUN apt-get update && \
-    apt-get -y install openssh-server && \
+    apt-get -y install openssh-server inotify-tools && \
     rm -rf /var/lib/apt/lists/* && \
     mkdir -p /var/run/sshd && \
     rm -f /etc/ssh/ssh_host_*key*

--- a/files/entrypoint
+++ b/files/entrypoint
@@ -16,21 +16,14 @@ function log() {
     echo "[$0] $*" >&2
 }
 
-# Allow running other programs, e.g. bash
-if [[ -z "$1" || "$1" =~ $reArgsMaybe ]]; then
-    startSshd=true
-else
-    startSshd=false
-fi
+function createUsers() {
 
-# Backward compatibility with legacy config path
-if [ ! -f "$userConfPath" ] && [ -f "$userConfPathLegacy" ]; then
-    mkdir -p "$(dirname $userConfPath)"
-    ln -s "$userConfPathLegacy" "$userConfPath"
-fi
+    # Backward compatibility with legacy config path
+    if [ ! -f "$userConfPath" ] && [ -f "$userConfPathLegacy" ]; then
+        mkdir -p "$(dirname $userConfPath)"
+        ln -s "$userConfPathLegacy" "$userConfPath"
+    fi
 
-# Create users only on first run
-if [ ! -f "$userConfFinalPath" ]; then
     mkdir -p "$(dirname $userConfFinalPath)"
 
     if [ -f "$userConfPath" ]; then
@@ -71,7 +64,26 @@ if [ ! -f "$userConfFinalPath" ]; then
     if [ ! -f /etc/ssh/ssh_host_rsa_key ]; then
         ssh-keygen -t rsa -b 4096 -f /etc/ssh/ssh_host_rsa_key -N ''
     fi
+}
+
+function checkUsersUpdate() {
+    # Check for new users
+    while [ true ]; do
+        inotifywait -e modify $userConfPath
+        createUsers
+        sleep 1
+    done
+}
+
+# Allow running other programs, e.g. bash
+if [[ -z "$1" || "$1" =~ $reArgsMaybe ]]; then
+    startSshd=true
+else
+    startSshd=false
 fi
+
+createUsers
+checkUsersUpdate &
 
 # Source custom scripts, if any
 if [ -d /etc/sftp.d ]; then


### PR DESCRIPTION
When you have users.conf mounted, eventually you want to recreate users with zero downtime.
This PR uses inotifywait to listen modifications in users.conf and recreate users.