### PR TITLE
Create an option to use LDAP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,23 @@
 FROM debian:stretch
 MAINTAINER Adrian Dvergsdal [atmoz.net]
 
+COPY files/ldap.debconf /ldap.debconf
+RUN debconf-set-selections < /ldap.debconf
+
 # Steps done in one RUN layer:
 # - Install packages
 # - OpenSSH needs /var/run/sshd to run
 # - Remove generic host keys, entrypoint generates unique keys
 RUN apt-get update && \
-    apt-get -y install openssh-server && \
+    apt-get -y install openssh-server libpam-ldapd libnss-ldapd libpam-script && \
     rm -rf /var/lib/apt/lists/* && \
     mkdir -p /var/run/sshd && \
     rm -f /etc/ssh/ssh_host_*key*
 
 COPY files/sshd_config /etc/ssh/sshd_config
 COPY files/create-sftp-user /usr/local/bin/
+COPY files/enable_ldap /usr/local/bin
+COPY files/ldap-pam-script.sh /usr/share/libpam-script/
 COPY files/entrypoint /
 
 EXPOSE 22

--- a/README.md
+++ b/README.md
@@ -33,6 +33,19 @@ This is an automated build linked with the [debian](https://hub.docker.com/_/deb
     want them to upload files.
   - For consistent server fingerprint, mount your own host keys (i.e. `/etc/ssh/ssh_host_*`)
 
+## Using LDAP
+To use LDAP set the following environment variables:
+
+- `ENABLE_LDAP` (Value doesn't matter, just needs to be set)
+- `LDAP_BINDDN`
+- `LDAP_BINDPW`
+- `LDAP_SEARCH_BASE`
+- `LDAP_URI`
+
+Note: `SFTP_USERS` variable is ignored, this means additional directories are
+not created. In the users home directory (which is r/w for root only), `sftp`
+directory is created. The user will have r/w the sftp directory.
+
 # Examples
 
 ## Simplest docker run example
@@ -98,7 +111,7 @@ docker run \
     'foo:$1$0G2g0GSt$ewU0t6GXG15.0hWoOX8X9.:e:1001'
 ```
 
-Tip: you can use [atmoz/makepasswd](https://hub.docker.com/r/atmoz/makepasswd/) to generate encrypted passwords:  
+Tip: you can use [atmoz/makepasswd](https://hub.docker.com/r/atmoz/makepasswd/) to generate encrypted passwords:
 `echo -n "your-password" | docker run -i --rm atmoz/makepasswd --crypt-md5 --clearfrom=-`
 
 ## Logging in with SSH keys

--- a/files/enable_ldap
+++ b/files/enable_ldap
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+for f in pam_script_acct pam_script_auth pam_script_passwd pam_script_ses_close pam_script_ses_open
+do
+  ln -s /usr/share/libpam-script/ldap-pam-script.sh /usr/share/libpam-script/$f
+done
+
+pam-auth-update --package
+
+cat <<EOF > /etc/nslcd.conf
+uid nslcd
+gid nslcd
+binddn ${LDAP_BINDDN}
+bindpw ${LDAP_BINDPW}
+uri ${LDAP_URI}
+base  ${LDAP_SEARCH_BASE}
+tls_reqcert never
+tls_cacertfile /etc/ssl/certs/ca-certificates.crt
+pagesize 1000
+referrals off
+filter passwd (&(objectClass=user)(!(objectClass=computer))(uidNumber=*)(unixHomeDirectory=*))
+map    passwd uid              sAMAccountName
+map    passwd homeDirectory    unixHomeDirectory
+map    passwd gecos            displayName
+filter shadow (&(objectClass=user)(!(objectClass=computer))(uidNumber=*)(unixHomeDirectory=*))
+map    shadow uid              sAMAccountName
+map    shadow shadowLastChange pwdLastSet
+filter group  (objectClass=group)
+EOF
+
+echo "UsePAM yes" >> /etc/ssh/sshd_config
+
+if ! nslcd -c
+then
+  nslcd
+fi
+

--- a/files/entrypoint
+++ b/files/entrypoint
@@ -32,36 +32,44 @@ fi
 # Create users only on first run
 if [ ! -f "$userConfFinalPath" ]; then
     mkdir -p "$(dirname $userConfFinalPath)"
+    # Enable LDAP if requested
+    if [ -n "${ENABLE_LDAP}" ]
+    then
+      log "Enabling LDAP auth"
+      /usr/local/bin/enable_ldap
+      touch ${userConfFinalPath}
+    else
+      if [ -f "$userConfPath" ]; then
+          # Append mounted config to final config
+          grep -v -E "$reArgSkip" < "$userConfPath" > "$userConfFinalPath"
+      fi
 
-    if [ -f "$userConfPath" ]; then
-        # Append mounted config to final config
-        grep -v -E "$reArgSkip" < "$userConfPath" > "$userConfFinalPath"
-    fi
 
-    if $startSshd; then
-        # Append users from arguments to final config
-        for user in "$@"; do
-            echo "$user" >> "$userConfFinalPath"
-        done
-    fi
+      if $startSshd; then
+          # Append users from arguments to final config
+          for user in "$@"; do
+              echo "$user" >> "$userConfFinalPath"
+          done
+      fi
 
-    if [ -n "$SFTP_USERS" ]; then
-        # Append users from environment variable to final config
-        IFS=" " read -r -a usersFromEnv <<< "$SFTP_USERS"
-        for user in "${usersFromEnv[@]}"; do
-            echo "$user" >> "$userConfFinalPath"
-        done
-    fi
+      if [ -n "$SFTP_USERS" ]; then
+          # Append users from environment variable to final config
+          IFS=" " read -r -a usersFromEnv <<< "$SFTP_USERS"
+          for user in "${usersFromEnv[@]}"; do
+              echo "$user" >> "$userConfFinalPath"
+          done
+      fi
 
-    # Check that we have users in config
-    if [ -f "$userConfFinalPath" ] && [ "$(wc -l < "$userConfFinalPath")" -gt 0 ]; then
-        # Import users from final conf file
-        while IFS= read -r user || [[ -n "$user" ]]; do
-            create-sftp-user "$user"
-        done < "$userConfFinalPath"
-    elif $startSshd; then
-        log "FATAL: No users provided!"
-        exit 3
+      # Check that we have users in config
+      if [ -f "$userConfFinalPath" ] && [ "$(wc -l < "$userConfFinalPath")" -gt 0 ]; then
+          # Import users from final conf file
+          while IFS= read -r user || [[ -n "$user" ]]; do
+              create-sftp-user "$user"
+          done < "$userConfFinalPath"
+      elif $startSshd; then
+          log "FATAL: No users provided!"
+          exit 3
+      fi
     fi
 
     # Generate unique ssh keys for this container, if needed

--- a/files/ldap-pam-script.sh
+++ b/files/ldap-pam-script.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+USER_GROUP=$(id -g ${PAM_USER})
+USER_HOME="$(getent passwd ${PAM_USER} | cut -d ':' -f 6)"
+
+do_session() {
+  install -d -o root -g root -m 0755 ${USER_HOME}
+  install -d -o $PAM_USER -g $USER_GROUP -m 0700 ${USER_HOME}/sftp
+}
+
+case "$PAM_TYPE" in
+  session)
+    do_session
+    ;;
+  *)
+    true
+    ;;
+esac

--- a/files/ldap.debconf
+++ b/files/ldap.debconf
@@ -1,0 +1,14 @@
+nslcd nslcd/ldap-binddn  string
+nslcd nslcd/ldap-bindpw   password
+nslcd nslcd/ldap-base string
+nslcd nslcd/ldap-uris string
+nslcd libraries/restart-without-asking: boolean true
+nslcd nslcd/ldap-auth-type    select  simple
+nslcd nslcd/ldap-starttls     boolean false
+nslcd nslcd/ldap-reqcert      select  never
+libpam-runtime        libpam-runtime/profiles multiselect     ccreds-save, unix, ldap, mkhomedir , ccreds-check
+libnss-ldapd  libnss-ldapd/nsswitch   multiselect     group, passwd, shadow
+libnss-ldapd  libnss-ldapd/clean_nsswitch     boolean false
+libnss-ldapd:amd64    libnss-ldapd/nsswitch   multiselect     group, passwd, shadow
+libnss-ldapd:amd64    libnss-ldapd/clean_nsswitch     boolean false
+


### PR DESCRIPTION
This commit introduces a feature that gives the option to use LDAP. The
implementation is through libpam-ldap and libnss-ldap. User home directories are
automatically created using libpam-script, but SFTP_USERS variable will be
ignored.

Further improvement would be to update `files/create-sftp-user` script, allow
libpam-script to create user directories.