### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ docker run \
 /host/users.conf:
 
 ```
-foo:123:1001:100
-bar:abc:1002:100
-baz:xyz:1003:100
+foo:123:1001:100:
+bar:abc:1002:100:
+baz:xyz:1003:100:
 ```
 
 ## Encrypted password


### PR DESCRIPTION
Add a colon character at the end of each line in /host/users.conf. Without it, I get an error message during startup: 

```
[entrypoint] Parsing user data: "foo:123:1001:100"
[entrypoint] ERROR: Invalid GID "100", do not match required regex pattern: [[:digit:]]*

```