### PR TITLE
Fix ShellCheck 

### DIFF
--- a/tests/run
+++ b/tests/run
@@ -354,6 +354,6 @@ function testDuplicateSshKeys() {
 ## Run
 ##############################################################################
 
-# shellcheck disable=SC1090
+# shellcheck disable=SC1091
 source "$testDir/shunit2/shunit2"
 # Nothing happens after this


### PR DESCRIPTION
Atmoz/SFTP build is failing since 2021-04-20 because of an error while running ShellCheck. Builds have started failing after a [new version of ShellCheck has been released](https://github.com/koalaman/shellcheck/blob/master/CHANGELOG.md).

If I understood it correctly, `shunit2` should be ignored while running ShellCheck. My fix changes the ignore rule to a proper one – [SC1091](https://github.com/koalaman/shellcheck/wiki/SC1091).

First failing build
https://github.com/atmoz/sftp/actions/runs/767049029

Last successful build
https://github.com/atmoz/sftp/actions/runs/763472088