### PR TITLE
Install OpenSSH with PAM support in Alpine

### DIFF
--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -6,7 +6,8 @@ MAINTAINER Adrian Dvergsdal [atmoz.net]
 # - OpenSSH needs /var/run/sshd to run
 # - Remove generic host keys, entrypoint generates unique keys
 RUN echo "@community http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
-    apk add --no-cache bash shadow@community openssh openssh-sftp-server && \
+    apk add --no-cache bash shadow@community openssh-server-pam openssh-sftp-server && \
+    ln -s /usr/sbin/sshd.pam /usr/sbin/sshd && \
     mkdir -p /var/run/sshd && \
     rm -f /etc/ssh/ssh_host_*key*
 


### PR DESCRIPTION
This should not affect those that do not use PAM (`UsePAM` is by default disabled in `sshd_config`)