### PR TITLE
Bug: Fix command causing unit tests & builds to fail

### DIFF
--- a/files/create-sftp-user
+++ b/files/create-sftp-user
@@ -34,7 +34,7 @@ IFS=':' read -ra args <<< "$1"
 
 skipIndex=0
 chpasswdOptions=""
-useraddOptions=(--no-user-group --badnames)
+useraddOptions=(--no-user-group --badname)
 
 user="${args[0]}"; validateArg "username" "$user" "$reUser" || exit 1
 pass="${args[1]}"; validateArg "password" "$pass" "$rePass" || exit 1


### PR DESCRIPTION
Unit tests are failing

<details>
  <summary><b>Failing Unit Tests</b></summary>

***Debian Image:***
```sh
sudo ./run atmoz/sftp:latest
[sudo] password for osadmin: 
Generating public/private ed25519 key pair.
ssh_askpass: exec(/usr/bin/ssh-askpass): No such file or directory
ssh_askpass: exec(/usr/bin/ssh-askpass): No such file or directory
Your identification has been saved in /tmp/atmoz_sftp_4cls/ssh_host_ed25519_key
Your public key has been saved in /tmp/atmoz_sftp_4cls/ssh_host_ed25519_key.pub
The key fingerprint is:
SHA256:Bg8UnvSKhmKsVC5CBrzcDUDINWP0pbAyAdifBgaocw4 root@osadmin-virtual-machine
The key's randomart image is:
+--[ED25519 256]--+
|%*+B  +o         |
|=o*.*+oo         |
|o*o=o+= .        |
|Eo*o+o =         |
|oX.oo . S        |
|=.o.   .         |
|.                |
|                 |
|                 |
+----[SHA256]-----+
testSmallestUserConfig
ASSERT:user created
shunit2:ERROR testSmallestUserConfig() returned non-zero return code.
testCreateUserWithDot
ASSERT:user created
shunit2:ERROR testCreateUserWithDot() returned non-zero return code.
testUserCustomUidAndGid
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
exec /bin/sh: exec format error
ASSERT:custom UID
ASSERT:custom GID
ASSERT:expected:<uid=1234(u) gid=4321(group_4321) groups=4321(group_4321)> but was:<>
shunit2:ERROR testUserCustomUidAndGid() returned non-zero return code.
testCommandPassthrough
ASSERT:command passthrough
shunit2:ERROR testCommandPassthrough() returned non-zero return code.
testUsersConf
Waiting for atmoz_sftp_testUsersConf to open port 22 ................................. TIMEOUT
ASSERT:waitForServer
Error response from daemon: Container 0bd7c70a48940d76bb8c1acd070be631355a67d35c2fd6bdb87accfa10ab7f9a is not running
ASSERT:user-from-conf
Error response from daemon: Container 0bd7c70a48940d76bb8c1acd070be631355a67d35c2fd6bdb87accfa10ab7f9a is not running
ASSERT:test
Error response from daemon: Container 0bd7c70a48940d76bb8c1acd070be631355a67d35c2fd6bdb87accfa10ab7f9a is not running
ASSERT:user.with.dot
Error response from daemon: Container 0bd7c70a48940d76bb8c1acd070be631355a67d35c2fd6bdb87accfa10ab7f9a is not running
ASSERT:dirs exists
shunit2:ERROR testUsersConf() returned non-zero return code.
testLegacyUsersConf
Waiting for atmoz_sftp_testLegacyUsersConf to open port 22 ................................. TIMEOUT
ASSERT:waitForServer
Error response from daemon: Container d6c1a32f1857b7f4e83db0eb7b6e02bacc6d134ab9051b5f773f976acd931bd5 is not running
ASSERT:user-from-conf
shunit2:ERROR testLegacyUsersConf() returned non-zero return code.
testCreateUsersUsingEnv
Waiting for atmoz_sftp_testCreateUsersUsingEnv to open port 22 ................................. TIMEOUT
ASSERT:waitForServer
Error response from daemon: Container da8b2e88c4240cc320464580fbf226d283130fcd57d9468497430bbf356f67dc is not running
ASSERT:user-from-env
Error response from daemon: Container da8b2e88c4240cc320464580fbf226d283130fcd57d9468497430bbf356f67dc is not running
ASSERT:user-from-env-2
shunit2:ERROR testCreateUsersUsingEnv() returned non-zero return code.
testCreateUsersUsingCombo
Waiting for atmoz_sftp_testCreateUsersUsingCombo to open port 22 ................................. TIMEOUT
ASSERT:waitForServer
Error response from daemon: Container 37e8ffe6f1bc011741a2aece0acb8280425c73782a747cf7b8d0bc00015c887b is not running
ASSERT:user-from-conf
Error response from daemon: Container 37e8ffe6f1bc011741a2aece0acb8280425c73782a747cf7b8d0bc00015c887b is not running
ASSERT:user-from-env
Error response from daemon: Container 37e8ffe6f1bc011741a2aece0acb8280425c73782a747cf7b8d0bc00015c887b is not running
ASSERT:user-from-cmd
shunit2:ERROR testCreateUsersUsingCombo() returned non-zero return code.
testWriteAccessToAutocreatedDirs
Waiting for atmoz_sftp_testWriteAccessToAutocreatedDirs to open port 22 ................................. TIMEOUT
ASSERT:waitForServer
ASSERT:runSftpCommands
Error response from daemon: Container d619ca88569a3e04b8c05b426e533c7103e793024786909accdfb3d02e9a4cd7 is not running
ASSERT:testdir write access
Error response from daemon: Container d619ca88569a3e04b8c05b426e533c7103e793024786909accdfb3d02e9a4cd7 is not running
ASSERT:dir with spaces write access
shunit2:ERROR testWriteAccessToAutocreatedDirs() returned non-zero return code.
testWriteAccessToLimitedChroot
Waiting for atmoz_sftp_testWriteAccessToLimitedChroot to open port 22 ................................. TIMEOUT
ASSERT:waitForServer
ASSERT:runSftpCommands
Error response from daemon: Container db4fa39b1c8e6f0d148e0fbe4e3ad88f9f1fc41d9090e6b47a50f9d9b0ed7d1b is not running
ASSERT:limited chroot write access
shunit2:ERROR testWriteAccessToLimitedChroot() returned non-zero return code.
testBindmountDirScript
Waiting for atmoz_sftp_testBindmountDirScript to open port 22 ................................. TIMEOUT
ASSERT:waitForServer
ASSERT:runSftpCommands
Error response from daemon: Container f4ffa07c6f8e3f155c483e637d2f6408d0299c7119c5c5ee6db8ecb475b5dbf1 is not running
ASSERT:directory exist
shunit2:ERROR testBindmountDirScript() returned non-zero return code.
testDuplicateSshKeys
Waiting for atmoz_sftp_testDuplicateSshKeys to open port 22 ................................. TIMEOUT
ASSERT:waitForServer
Error response from daemon: Container de5086eb2a84fe941eb510157ae7a4d14d18bf0adc776bfa00a00ef66e1d8c42 is not running
ASSERT:expected:<1> but was:<>
shunit2:ERROR testDuplicateSshKeys() returned non-zero return code.

Ran 12 tests.

FAILED (failures=44)
```

***Alpine Image:***
```sh
sudo ./run atmoz/sftp:alpine
Generating public/private ed25519 key pair.
ssh_askpass: exec(/usr/bin/ssh-askpass): No such file or directory
ssh_askpass: exec(/usr/bin/ssh-askpass): No such file or directory
Your identification has been saved in /tmp/atmoz_sftp_IM7Y/ssh_host_ed25519_key
Your public key has been saved in /tmp/atmoz_sftp_IM7Y/ssh_host_ed25519_key.pub
The key fingerprint is:
SHA256:WiT3JaBsXWIRgDvRTMQcI+xP3/HZ/b5Go5bG5uEnYIw root@osadmin-virtual-machine
The key's randomart image is:
+--[ED25519 256]--+
|   ..O*o*o.      |
|    +o== +       |
|   . o= + . .    |
|    +..+ ..o     |
|     + .S.+o o . |
|      .o.E.+o .o.|
|      .   . o.+ o|
|            .O.o.|
|            =o+oo|
+----[SHA256]-----+
testSmallestUserConfig
ASSERT:user created
shunit2:ERROR testSmallestUserConfig() returned non-zero return code.
testCreateUserWithDot
ASSERT:user created
shunit2:ERROR testCreateUserWithDot() returned non-zero return code.
testUserCustomUidAndGid
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
exec /bin/sh: exec format error
ASSERT:custom UID
ASSERT:custom GID
ASSERT:expected:<uid=1234(u) gid=4321(group_4321) groups=4321(group_4321)> but was:<>
shunit2:ERROR testUserCustomUidAndGid() returned non-zero return code.
testCommandPassthrough
ASSERT:command passthrough
shunit2:ERROR testCommandPassthrough() returned non-zero return code.
testUsersConf
Waiting for atmoz_sftp_testUsersConf to open port 22 ................................. TIMEOUT
ASSERT:waitForServer
Error response from daemon: Container 564540ac76787fd23ae4bc8a2a56fc2359ae1c28941e0dbe27c26141082e622d is not running
ASSERT:user-from-conf
Error response from daemon: Container 564540ac76787fd23ae4bc8a2a56fc2359ae1c28941e0dbe27c26141082e622d is not running
ASSERT:test
Error response from daemon: Container 564540ac76787fd23ae4bc8a2a56fc2359ae1c28941e0dbe27c26141082e622d is not running
ASSERT:user.with.dot
Error response from daemon: Container 564540ac76787fd23ae4bc8a2a56fc2359ae1c28941e0dbe27c26141082e622d is not running
ASSERT:dirs exists
shunit2:ERROR testUsersConf() returned non-zero return code.
testLegacyUsersConf
Waiting for atmoz_sftp_testLegacyUsersConf to open port 22 ................................. TIMEOUT
ASSERT:waitForServer
Error response from daemon: Container c7452f7ce477a5c741cad4285a2fce8e3f24b304945977f5a7e6e65c2ad8e5fe is not running
ASSERT:user-from-conf
shunit2:ERROR testLegacyUsersConf() returned non-zero return code.
testCreateUsersUsingEnv
Waiting for atmoz_sftp_testCreateUsersUsingEnv to open port 22 ................................. TIMEOUT
ASSERT:waitForServer
Error response from daemon: Container 3e6dd040a171e3b0bfc222e8b64376faa0448e2d8ce857b6cbe4461fff3a7dc0 is not running
ASSERT:user-from-env
Error response from daemon: Container 3e6dd040a171e3b0bfc222e8b64376faa0448e2d8ce857b6cbe4461fff3a7dc0 is not running
ASSERT:user-from-env-2
shunit2:ERROR testCreateUsersUsingEnv() returned non-zero return code.
testCreateUsersUsingCombo
Waiting for atmoz_sftp_testCreateUsersUsingCombo to open port 22 ................................. TIMEOUT
ASSERT:waitForServer
Error response from daemon: Container 6f049e8f99e74107a67ff74fe91db3e2d743567da38f940caee5f5fb87c5118e is not running
ASSERT:user-from-conf
Error response from daemon: Container 6f049e8f99e74107a67ff74fe91db3e2d743567da38f940caee5f5fb87c5118e is not running
ASSERT:user-from-env
Error response from daemon: Container 6f049e8f99e74107a67ff74fe91db3e2d743567da38f940caee5f5fb87c5118e is not running
ASSERT:user-from-cmd
shunit2:ERROR testCreateUsersUsingCombo() returned non-zero return code.
testWriteAccessToAutocreatedDirs
Waiting for atmoz_sftp_testWriteAccessToAutocreatedDirs to open port 22 ................................. TIMEOUT
ASSERT:waitForServer
ASSERT:runSftpCommands
Error response from daemon: Container f10a7c30f45b56b987512d7432eeb2284796a6d078fc5aaa4d0236bdaec549fb is not running
ASSERT:testdir write access
Error response from daemon: Container f10a7c30f45b56b987512d7432eeb2284796a6d078fc5aaa4d0236bdaec549fb is not running
ASSERT:dir with spaces write access
shunit2:ERROR testWriteAccessToAutocreatedDirs() returned non-zero return code.
testWriteAccessToLimitedChroot
Waiting for atmoz_sftp_testWriteAccessToLimitedChroot to open port 22 ................................. TIMEOUT
ASSERT:waitForServer
ASSERT:runSftpCommands
Error response from daemon: Container 93bf6a75efc9812b8e01c6b84b299420f177fb1a85fdcf767cd110015996ea91 is not running
ASSERT:limited chroot write access
shunit2:ERROR testWriteAccessToLimitedChroot() returned non-zero return code.
testBindmountDirScript
Waiting for atmoz_sftp_testBindmountDirScript to open port 22 ................................. TIMEOUT
ASSERT:waitForServer
ASSERT:runSftpCommands
Error response from daemon: Container ea2d88c90369f3ffaf3bc646c84fd0f248181b6c0280851104eeddb2ad09de57 is not running
ASSERT:directory exist
shunit2:ERROR testBindmountDirScript() returned non-zero return code.
testDuplicateSshKeys
Waiting for atmoz_sftp_testDuplicateSshKeys to open port 22 ................................. TIMEOUT
ASSERT:waitForServer
Error response from daemon: Container be147ffe96821d017a6e567cb1cd54b543401912edfc872bc5775336f4da0610 is not running
ASSERT:expected:<1> but was:<>
shunit2:ERROR testDuplicateSshKeys() returned non-zero return code.

Ran 12 tests.

FAILED (failures=44)
```
</details><p>

This is due to mistake in `create-sftp-user`. Fixed from `useraddOptions=(--no-user-group --badnames)` to `useraddOptions=(--no-user-group --badname)` and unit tests are now passing:


<details>
  <summary><b>Passing Unit Tests</b></summary>

***Debian Image:***
```sh
sudo ./run jmcombs/sftp:latest
Generating public/private ed25519 key pair.
ssh_askpass: exec(/usr/bin/ssh-askpass): No such file or directory
ssh_askpass: exec(/usr/bin/ssh-askpass): No such file or directory
Your identification has been saved in /tmp/atmoz_sftp_Hwij/ssh_host_ed25519_key
Your public key has been saved in /tmp/atmoz_sftp_Hwij/ssh_host_ed25519_key.pub
The key fingerprint is:
SHA256:LXHupigWnaIpY50wCEa0CMPJjG3yClfyyrg9Fe7IuMI root@osadmin-virtual-machine
The key's randomart image is:
+--[ED25519 256]--+
|Oo.              |
|=B= .            |
|o= +    . .      |
|o.o o    =       |
|== o o .S o      |
|+oo = o  o       |
|.=+*.o    o      |
|*EBo+  . o       |
|++ o .. .        |
+----[SHA256]-----+
testSmallestUserConfig
testCreateUserWithDot
testUserCustomUidAndGid
testCommandPassthrough
testUsersConf
Waiting for atmoz_sftp_testUsersConf to open port 22 .... OPEN
testLegacyUsersConf
Waiting for atmoz_sftp_testLegacyUsersConf to open port 22 .... OPEN
testCreateUsersUsingEnv
Waiting for atmoz_sftp_testCreateUsersUsingEnv to open port 22 .... OPEN
testCreateUsersUsingCombo
Waiting for atmoz_sftp_testCreateUsersUsingCombo to open port 22 .... OPEN
testWriteAccessToAutocreatedDirs
Waiting for atmoz_sftp_testWriteAccessToAutocreatedDirs to open port 22 .... OPEN
testWriteAccessToLimitedChroot
Waiting for atmoz_sftp_testWriteAccessToLimitedChroot to open port 22 .... OPEN
testBindmountDirScript
Waiting for atmoz_sftp_testBindmountDirScript to open port 22 .... OPEN
testDuplicateSshKeys
Waiting for atmoz_sftp_testDuplicateSshKeys to open port 22 .... OPEN

Ran 12 tests.

OK
```

***Alpine Image:***
```sh
sudo ./run jmcombs/sftp:alpine
Generating public/private ed25519 key pair.
ssh_askpass: exec(/usr/bin/ssh-askpass): No such file or directory
ssh_askpass: exec(/usr/bin/ssh-askpass): No such file or directory
Your identification has been saved in /tmp/atmoz_sftp_r7zR/ssh_host_ed25519_key
Your public key has been saved in /tmp/atmoz_sftp_r7zR/ssh_host_ed25519_key.pub
The key fingerprint is:
SHA256:U6qExVH91dB9e2pknEgkvT8KRn1U8jNxR7q6zPe74Ow root@osadmin-virtual-machine
The key's randomart image is:
+--[ED25519 256]--+
|      .....o. oB*|
|     . .  ..o o+O|
|      o   .+ *.++|
|     o   o. = *o+|
|    . . S.   =...|
|     . . .o  .=  |
|      .  . ..+ . |
|           o+.o  |
|            =E ++|
+----[SHA256]-----+
testSmallestUserConfig
testCreateUserWithDot
testUserCustomUidAndGid
testCommandPassthrough
testUsersConf
Waiting for atmoz_sftp_testUsersConf to open port 22 ...... OPEN
testLegacyUsersConf
Waiting for atmoz_sftp_testLegacyUsersConf to open port 22 ..... OPEN
testCreateUsersUsingEnv
Waiting for atmoz_sftp_testCreateUsersUsingEnv to open port 22 .... OPEN
testCreateUsersUsingCombo
Waiting for atmoz_sftp_testCreateUsersUsingCombo to open port 22 .... OPEN
testWriteAccessToAutocreatedDirs
Waiting for atmoz_sftp_testWriteAccessToAutocreatedDirs to open port 22 ..... OPEN
testWriteAccessToLimitedChroot
Waiting for atmoz_sftp_testWriteAccessToLimitedChroot to open port 22 ..... OPEN
testBindmountDirScript
Waiting for atmoz_sftp_testBindmountDirScript to open port 22 ...... OPEN
testDuplicateSshKeys
Waiting for atmoz_sftp_testDuplicateSshKeys to open port 22 ...... OPEN

Ran 12 tests.

OK
```
</details>
