### PR TITLE
Feature: Add SCP Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && \
 
 COPY files/sshd_config /etc/ssh/sshd_config
 COPY files/create-sftp-user /usr/local/bin/
+COPY files/permit-scp.sh /usr/local/bin/
 COPY files/entrypoint /
 
 EXPOSE 22

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -13,6 +13,7 @@ RUN echo "@community http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /et
 
 COPY files/sshd_config /etc/ssh/sshd_config
 COPY files/create-sftp-user /usr/local/bin/
+COPY files/permit-scp.sh /usr/local/bin/
 COPY files/entrypoint /
 
 EXPOSE 22

--- a/files/create-sftp-user
+++ b/files/create-sftp-user
@@ -34,7 +34,7 @@ IFS=':' read -ra args <<< "$1"
 
 skipIndex=0
 chpasswdOptions=""
-useraddOptions=(--no-user-group --badnames)
+useraddOptions=(--no-user-group --badname)
 
 user="${args[0]}"; validateArg "username" "$user" "$reUser" || exit 1
 pass="${args[1]}"; validateArg "password" "$pass" "$rePass" || exit 1

--- a/files/permit-scp.sh
+++ b/files/permit-scp.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Permit scp
+case $SSH_ORIGINAL_COMMAND in
+ 'scp'*)
+    $SSH_ORIGINAL_COMMAND
+    ;;
+ *)
+    echo "Access Denied"
+    ;;
+esac

--- a/files/sshd_config
+++ b/files/sshd_config
@@ -18,5 +18,8 @@ Subsystem sftp internal-sftp
 ForceCommand internal-sftp
 ChrootDirectory %h
 
+# Permit SCP
+ForceCommand /usr/local/bin/permit-scp.sh
+
 # Enable this for more logs
 #LogLevel VERBOSE


### PR DESCRIPTION
Adding SCP support based on requests from [allowing an option for a limited ssh shell instead of internal-sftp #116](https://github.com/atmoz/sftp/issues/116). 

`rssh` and `scponly` appear to be stale projects and the replacement is [GNU Rush](https://www.gnu.org.ua/software/rush/).Based on initial review, it seems this would be a bit overkill and overneingeering for the stated goal of this project. Also, Rush is available in `apt` for Debian but not in `apk` for Alpine which makes installing and maintaining in CI a little more challenging, as well.

I borrowed from [this answer](https://serverfault.com/a/1114258/965762) to a question on serverfault [Allow SCP but not actual login using SSH](https://serverfault.com/questions/83856/allow-scp-but-not-actual-login-using-ssh/) to create the solution.

Unit tests are passing for both Alpine and Debian.

<details>
  <summary><b>Passing Unit Tests</b></summary>

***Debian Image:***
```sh
sudo ./run jmcombs/sftp:latest
Generating public/private ed25519 key pair.
ssh_askpass: exec(/usr/bin/ssh-askpass): No such file or directory
ssh_askpass: exec(/usr/bin/ssh-askpass): No such file or directory
Your identification has been saved in /tmp/atmoz_sftp_C9yP/ssh_host_ed25519_key
Your public key has been saved in /tmp/atmoz_sftp_C9yP/ssh_host_ed25519_key.pub
The key fingerprint is:
SHA256:VF5BbAza5a2GMWa2T1rrHzIzn/kKFE9qVL8gMM7cj8o root@osadmin-virtual-machine
The key's randomart image is:
+--[ED25519 256]--+
|         oo==..  |
|        +=+++o . |
|        o+O++.o .|
|       . + *+*. .|
|        S o.O... |
|        . .O .   |
|         E. O .  |
|           . B + |
|            ..*o.|
+----[SHA256]-----+
testSmallestUserConfig
testCreateUserWithDot
testUserCustomUidAndGid
testCommandPassthrough
testUsersConf
Waiting for atmoz_sftp_testUsersConf to open port 22 .... OPEN
testLegacyUsersConf
Waiting for atmoz_sftp_testLegacyUsersConf to open port 22 .... OPEN
testCreateUsersUsingEnv
Waiting for atmoz_sftp_testCreateUsersUsingEnv to open port 22 .... OPEN
testCreateUsersUsingCombo
Waiting for atmoz_sftp_testCreateUsersUsingCombo to open port 22 .... OPEN
testWriteAccessToAutocreatedDirs
Waiting for atmoz_sftp_testWriteAccessToAutocreatedDirs to open port 22 .... OPEN
testWriteAccessToLimitedChroot
Waiting for atmoz_sftp_testWriteAccessToLimitedChroot to open port 22 .... OPEN
testBindmountDirScript
Waiting for atmoz_sftp_testBindmountDirScript to open port 22 .... OPEN
testDuplicateSshKeys
Waiting for atmoz_sftp_testDuplicateSshKeys to open port 22 .... OPEN

Ran 12 tests.

OK
```

***Alpine Image:***
```sh
sudo ./run jmcombs/sftp:alpine
Generating public/private ed25519 key pair.
ssh_askpass: exec(/usr/bin/ssh-askpass): No such file or directory
ssh_askpass: exec(/usr/bin/ssh-askpass): No such file or directory
Your identification has been saved in /tmp/atmoz_sftp_gh4u/ssh_host_ed25519_key
Your public key has been saved in /tmp/atmoz_sftp_gh4u/ssh_host_ed25519_key.pub
The key fingerprint is:
SHA256:T5fba5otjFZmzROQx7Qt+rpeUuOAkFMuXnMNJ8jLKUM root@osadmin-virtual-machine
The key's randomart image is:
+--[ED25519 256]--+
|         ...o+o  |
|        E+o o=oo |
|       .=.+o.o+ .|
|       .o=++ o.. |
|        Soo =oo. |
|         o .+B+. |
|          .*o =. |
|          o o*.. |
|         . .*=o  |
+----[SHA256]-----+
testSmallestUserConfig
testCreateUserWithDot
testUserCustomUidAndGid
testCommandPassthrough
testUsersConf
Waiting for atmoz_sftp_testUsersConf to open port 22 ..... OPEN
testLegacyUsersConf
Waiting for atmoz_sftp_testLegacyUsersConf to open port 22 ....... OPEN
testCreateUsersUsingEnv
Waiting for atmoz_sftp_testCreateUsersUsingEnv to open port 22 ..... OPEN
testCreateUsersUsingCombo
Waiting for atmoz_sftp_testCreateUsersUsingCombo to open port 22 ..... OPEN
testWriteAccessToAutocreatedDirs
Waiting for atmoz_sftp_testWriteAccessToAutocreatedDirs to open port 22 ..... OPEN
testWriteAccessToLimitedChroot
Waiting for atmoz_sftp_testWriteAccessToLimitedChroot to open port 22 ...... OPEN
testBindmountDirScript
Waiting for atmoz_sftp_testBindmountDirScript to open port 22 ..... OPEN
testDuplicateSshKeys
Waiting for atmoz_sftp_testDuplicateSshKeys to open port 22 .... OPEN

Ran 12 tests.

OK
```

</details>