### PR TITLE
Feature/central authorized keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ docker run \
 Tip: you can use this Python code to generate encrypted passwords:  
 `docker run --rm python:alpine python -c "import crypt; print(crypt.crypt('YOUR_PASSWORD'))"`
 
-## Logging in with SSH keys
+## Logging in with SSH keys in ~/.ssh/authorized_keys
 
 Mount public keys in the user's `.ssh/keys/` directory. All keys are automatically appended to `.ssh/authorized_keys` (you can't mount this file directly, because OpenSSH requires limited file permissions). In this example, we do not provide any password, so the user `foo` can only login with his SSH key.
 
@@ -107,6 +107,31 @@ Mount public keys in the user's `.ssh/keys/` directory. All keys are automatical
 docker run \
     -v <host-dir>/id_rsa.pub:/home/foo/.ssh/keys/id_rsa.pub:ro \
     -v <host-dir>/id_other.pub:/home/foo/.ssh/keys/id_other.pub:ro \
+    -v <host-dir>/share:/home/foo/share \
+    -p 2222:22 -d atmoz/sftp \
+    foo::1001
+```
+
+## Logging in with SSH keys in /etc/ssh/authorized_keys/%u/authorized_keys
+
+For each user create the `authorized_keys` file and put it into a directory structure like this:
+
+```text
+all_keys
+ |------- user1
+ |         `----- authorized_keys
+ |------- user2
+ |         `----- authorized_keys
+ :
+ `------- userN
+           `----- authorized_keys
+```
+
+Mount this directory ass `/etc/ssh/authorized_keys`
+
+```
+docker run \
+    -v <host-dir>/all_keys:/etc/ssh/authorized_keys:ro \
     -v <host-dir>/share:/home/foo/share \
     -p 2222:22 -d atmoz/sftp \
     foo::1001

--- a/files/sshd_config
+++ b/files/sshd_config
@@ -18,5 +18,7 @@ Subsystem sftp internal-sftp
 ForceCommand internal-sftp
 ChrootDirectory %h
 
+AuthorizedKeysFile %h/.ssh/authorized_keys /etc/ssh/authorized_keys/%u/authorized_keys
+
 # Enable this for more logs
-#LogLevel VERBOSE
+LogLevel VERBOSE

--- a/files/sshd_config
+++ b/files/sshd_config
@@ -21,4 +21,4 @@ ChrootDirectory %h
 AuthorizedKeysFile %h/.ssh/authorized_keys /etc/ssh/authorized_keys/%u/authorized_keys
 
 # Enable this for more logs
-LogLevel VERBOSE
+#LogLevel VERBOSE


### PR DESCRIPTION
My goal was to keep my user settings, including their public keys, in a repository.

For this it is quite cumbersome to have their keys in `~/.ssh/keys` as I would need to mount each and every user's keys directory.

As I already knew from my previous setup, that ssh can take `authorized_keys` from other locations, I adjusted `sshd_config` accordingly.

Please find it in this PR.

This way I can put all my user's `authorized_keys` files in a common directory and mount this under `/etc/ssh/authorized_keys`.

So `foo`´s file will be located in (e.g.) `<host_dir>/all_keys/foo/authorized_keys` and by mounting `<host_dir>/all_keys` to `/etc/authorized_keys`, I can give them access.

I hope this helps others too.

P.S.: Your original way of having key files in `~/.ssh/keys` still works.