### PR TITLE
Enable authorized keys in /etc/ssh/authorized_keys

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ RUN apt-get update && \
     apt-get -y install openssh-server && \
     rm -rf /var/lib/apt/lists/* && \
     mkdir -p /var/run/sshd && \
-    rm -f /etc/ssh/ssh_host_*key*
+    rm -f /etc/ssh/ssh_host_*key* && \
+    mkdir -p /etc/sshd_authorized_keys
 
 COPY files/sshd_config /etc/ssh/sshd_config
 COPY files/create-sftp-user /usr/local/bin/

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -9,7 +9,8 @@ RUN echo "@community http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /et
     apk add --no-cache bash shadow@community openssh-server-pam openssh-sftp-server && \
     ln -s /usr/sbin/sshd.pam /usr/sbin/sshd && \
     mkdir -p /var/run/sshd && \
-    rm -f /etc/ssh/ssh_host_*key*
+    rm -f /etc/ssh/ssh_host_*key* && \
+    mkdir -p /etc/sshd_authorized_keys
 
 COPY files/sshd_config /etc/ssh/sshd_config
 COPY files/create-sftp-user /usr/local/bin/

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ docker run \
 Tip: you can use this Python code to generate encrypted passwords:  
 `docker run --rm python:alpine python -c "import crypt; print(crypt.crypt('YOUR_PASSWORD'))"`
 
-## Logging in with SSH keys
+## Logging in with SSH keys in ~/.ssh/authorized_keys
 
 Mount public keys in the user's `.ssh/keys/` directory. All keys are automatically appended to `.ssh/authorized_keys` (you can't mount this file directly, because OpenSSH requires limited file permissions). In this example, we do not provide any password, so the user `foo` can only login with his SSH key.
 
@@ -107,6 +107,34 @@ Mount public keys in the user's `.ssh/keys/` directory. All keys are automatical
 docker run \
     -v <host-dir>/id_rsa.pub:/home/foo/.ssh/keys/id_rsa.pub:ro \
     -v <host-dir>/id_other.pub:/home/foo/.ssh/keys/id_other.pub:ro \
+    -v <host-dir>/share:/home/foo/share \
+    -p 2222:22 -d atmoz/sftp \
+    foo::1001
+```
+
+## Logging in with SSH keys in /etc/ssh/authorized_keys/%u/authorized_keys
+
+If you can't or wouldn't want to put the keys into the user's `.ssh` directory, you can as well put them into a
+directory under `/etc/ssh`.
+
+Put the public keys in a `keys` directory. All keys are automatically appended to `/etc/ssh/authorized_keys/USERNAME/authorized_keys` (you can't mount this file directly, because OpenSSH requires limited file permissions).
+
+```text
+keys
+ |-- user1
+ |    `--- id_rs.pub
+ |-- user2
+ |    `--- id_rs.pub
+ :
+ `-- userN
+      `--- id_rs.pub
+```
+
+Mount this directory ass `/etc/ssh/keys`
+
+```
+docker run \
+    -v <host-dir>/keys:/etc/ssh/keys:ro \
     -v <host-dir>/share:/home/foo/share \
     -p 2222:22 -d atmoz/sftp \
     foo::1001

--- a/files/create-sftp-user
+++ b/files/create-sftp-user
@@ -83,18 +83,21 @@ fi
 # Add SSH keys to authorized_keys with valid permissions
 userKeysQueuedDir="/home/$user/.ssh/keys"
 if [ -d "$userKeysQueuedDir" ]; then
-    userKeysAllowedFileTmp="$(mktemp)"
     userKeysAllowedFile="/home/$user/.ssh/authorized_keys"
-
-    for publickey in "$userKeysQueuedDir"/*; do
-        cat "$publickey" >> "$userKeysAllowedFileTmp"
-    done
-
-    # Remove duplicate keys
-    sort < "$userKeysAllowedFileTmp" | uniq > "$userKeysAllowedFile"
+else
+    userKeysQueuedDir="/etc/ssh/keys/$user"
+    if [ -d "$userKeysQueuedDir" ]; then
+        userKeysAllowedFile="/etc/ssh/authorized_keys/$user/authorized_keys"
+        mkdir -p "/etc/ssh/authorized_keys/$user"
+        chmod 0700 "/etc/ssh/authorized_keys/$user"
+        chown "$uid:root" "/etc/ssh/authorized_keys/$user"
+    fi
+fi
+if [ -n "$userKeysAllowedFile" ]; then
+    sort -u "$userKeysQueuedDir"/* > "$userKeysAllowedFile"
 
     chown "$uid" "$userKeysAllowedFile"
-    chmod 600 "$userKeysAllowedFile"
+    chmod 0600 "$userKeysAllowedFile"
 fi
 
 # Make sure dirs exists

--- a/files/sshd_config
+++ b/files/sshd_config
@@ -18,5 +18,7 @@ Subsystem sftp internal-sftp
 ForceCommand internal-sftp
 ChrootDirectory %h
 
+AuthorizedKeysFile %h/.ssh/authorized_keys /etc/ssh/authorized_keys/%u/authorized_keys
+
 # Enable this for more logs
 #LogLevel VERBOSE


### PR DESCRIPTION
I didn't want to have my user's keys in their home directory, but in `/etc/ssh/…`.

This PR enables this.