### PR TITLE
Add build and test steps for the rocky image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,19 @@ jobs:
 
       - name: Test alpine image
         run: tests/run $IMAGE_NAME:alpine
+      
+      - name: Build rocky image
+        run: |
+          docker build . \
+            --pull=true \
+            --file=Dockerfile-rocky \
+            --tag="$IMAGE_NAME:rocky" \
+            --label="org.opencontainers.image.source=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" \
+            --label="org.opencontainers.image.revision=$GITHUB_SHA" \
+            --label="org.opencontainers.image.created=$(date --rfc-3339=seconds)"
+
+      - name: Test rocky image
+        run: tests/run $IMAGE_NAME:rocky
 
       - name: Verify signature
         if: github.ref == 'refs/heads/master'
@@ -78,9 +91,12 @@ jobs:
 
           TAG_DEBIAN=docker.pkg.github.com/$GITHUB_REPOSITORY/debian
           TAG_ALPINE=docker.pkg.github.com/$GITHUB_REPOSITORY/alpine
+          TAG_ROCKY=docker.pkg.github.com/$GITHUB_REPOSITORY/rocky
           docker tag $IMAGE_NAME:debian $TAG_DEBIAN
           docker tag $IMAGE_NAME:alpine $TAG_ALPINE
+          docker tag $IMAGE_NAME:rocky $TAG_ROCKY
           docker push $TAG_DEBIAN
           docker push $TAG_ALPINE
+          docker push $TAG_ROCKY
           docker logout docker.pkg.github.com
 

--- a/Dockerfile-rocky
+++ b/Dockerfile-rocky
@@ -1,0 +1,20 @@
+FROM rockylinux:9
+MAINTAINER Mathias Rhein [funkemedien.de]
+
+# Steps done in one RUN layer:
+# - Install packages
+# - OpenSSH needs /var/run/sshd to run
+# - Remove generic host keys, entrypoint generates unique keys
+RUN dnf -y update && \
+    dnf -y install openssh-server && \
+    dnf clean all && \
+    mkdir -p /var/run/sshd && \
+    rm -f /etc/ssh/ssh_host_*key*
+
+COPY files/sshd_config /etc/ssh/sshd_config
+COPY files/create-sftp-user /usr/local/bin/
+COPY files/entrypoint /
+
+EXPOSE 22
+
+ENTRYPOINT ["/entrypoint"]


### PR DESCRIPTION
- Added a new step to build the rocky image using Dockerfile-rocky
- Set appropriate tags and labels for the rocky image
- Added a new step to test the rocky image
- Tagged and pushed the rocky image to docker.pkg.github.com

New Dockerfile:
- Created a new Dockerfile called Dockerfile-rocky based on Rocky Linux 9
- Installed packages, configured OpenSSH, and exposed port 22