### PR TITLE
Add support for ECDSA key

### DIFF
--- a/files/entrypoint
+++ b/files/entrypoint
@@ -72,7 +72,7 @@ if [ ! -f "$userConfFinalPath" ]; then
         ssh-keygen -t rsa -b 4096 -f /etc/ssh/ssh_host_rsa_key -N ''
     fi
     if [ ! -f /etc/ssh/ssh_host_ecdsa_key ]; then
-        ssh-keygen -t rsa -b 4096 -f /etc/ssh/ssh_host_ecdsa_key -N ''
+        ssh-keygen -t ecdsa -b 521 -f /etc/ssh/ssh_host_ecdsa_key -N ''
     fi
 
     # Restrict access from other users

--- a/files/entrypoint
+++ b/files/entrypoint
@@ -71,6 +71,9 @@ if [ ! -f "$userConfFinalPath" ]; then
     if [ ! -f /etc/ssh/ssh_host_rsa_key ]; then
         ssh-keygen -t rsa -b 4096 -f /etc/ssh/ssh_host_rsa_key -N ''
     fi
+    if [ ! -f /etc/ssh/ssh_host_ecdsa_key ]; then
+        ssh-keygen -t rsa -b 4096 -f /etc/ssh/ssh_host_ecdsa_key -N ''
+    fi
 
     # Restrict access from other users
     chmod 600 /etc/ssh/ssh_host_ed25519_key || true

--- a/files/sshd_config
+++ b/files/sshd_config
@@ -3,6 +3,7 @@
 Protocol 2
 HostKey /etc/ssh/ssh_host_ed25519_key
 HostKey /etc/ssh/ssh_host_rsa_key
+HostKey /etc/ssh/ssh_host_ecdsa_key
 
 # Faster connection
 # See: https://github.com/atmoz/sftp/issues/11


### PR DESCRIPTION
Fixes issue #335 (and also #311) by adding:

1. generation of ECSDA key (if not supplied) into /entrypoint
2. use of said key in sshd_config

Tested using an SSH4J client application that exhibited the same connection failure.