### PR TITLE
sshd_config - make 'Port' config key overridable using an env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM debian:bullseye
 MAINTAINER Adrian Dvergsdal [atmoz.net]
 
+ENV SSHD_PORT 22
+
 # Steps done in one RUN layer:
 # - Install packages
 # - OpenSSH needs /var/run/sshd to run
@@ -14,7 +16,5 @@ RUN apt-get update && \
 COPY files/sshd_config /etc/ssh/sshd_config
 COPY files/create-sftp-user /usr/local/bin/
 COPY files/entrypoint /
-
-EXPOSE 22
 
 ENTRYPOINT ["/entrypoint"]

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Easy to use SFTP ([SSH File Transfer Protocol](https://en.wikipedia.org/wiki/SSH
     want them to upload files.
   - For consistent server fingerprint, mount your own host keys (i.e. `/etc/ssh/ssh_host_*`)
 - Override port
-  - The container will listen on the port 22 (default for sshd), but if for any reasons you want an another port to be used instead of the default, you can change it with the env var SSHD_PORT
+  - The container will internally listen on the port 22 (default port for sshd), but if for any reasons you want another port to be used internally instead of the default, you can change it with the env var SSHD_PORT
 
 # Examples
 
@@ -64,6 +64,12 @@ sftp:
     ports:
         - "2222:22"
     command: foo:pass:1001
+```
+
+### Overriding the default port, so that sshd doesn't listen port 22
+
+```
+docker run -e SSHD_PORT=1234 -p 1234:1234 -d atmoz/sftp foo:pass:::upload
 ```
 
 ### Logging in

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Easy to use SFTP ([SSH File Transfer Protocol](https://en.wikipedia.org/wiki/SSH
     own home directory, so make sure there are at least one subdirectory if you
     want them to upload files.
   - For consistent server fingerprint, mount your own host keys (i.e. `/etc/ssh/ssh_host_*`)
+- Override port
+  - The container will listen on the port 22 (default for sshd), but if for any reasons you want an another port to be used instead of the default, you can change it with the env var SSHD_PORT
 
 # Examples
 

--- a/files/entrypoint
+++ b/files/entrypoint
@@ -90,6 +90,9 @@ if [ -d /etc/sftp.d ]; then
     unset f
 fi
 
+
+sed -i "s/SSHD_PORT/$SSHD_PORT/" /etc/ssh/sshd_config
+
 if $startSshd; then
     log "Executing sshd"
     exec /usr/sbin/sshd -D -e

--- a/files/sshd_config
+++ b/files/sshd_config
@@ -20,3 +20,5 @@ ChrootDirectory %h
 
 # Enable this for more logs
 #LogLevel VERBOSE
+
+Port SSHD_PORT


### PR DESCRIPTION
As atmoz/sftp is a docker image by design, one can already simply change the exposed port of the running server using the appropriate docker run options, to map the internal port 22 to any external port. 
It works very well in the majority of cases, as I've been able to experiment it myself.

**However**, there are a few cases where it is either not wanted or not possible to use this port mapping features.

For example, if you use atmoz/sftp in a CircleCI build, you won't be able to change the port mapping ( https://discuss.circleci.com/t/change-db-containers-ports/30234/6 ), even while the port 22 is reserved by CircleCI, and not usable to containers launched in the tests.

I've read about the custom scripts located in `/etc/sftp.d` ( https://github.com/atmoz/sftp#execute-custom-scripts-or-applications ) that might already allow one to override everything we want, but that might sounds a bit overengineered to provide a custom executable bash scripts to update a simple config key (this is opinionated, I'm ready to hear any different opinions on this)

Given the reasons listed above, I feel that it is reasonable to allow a user to override the SSHD port using a simple environment variable.

This Pull Request suggests an implementation of this.