### PR TITLE
Enable sshd_config.d subfiles

### DIFF
--- a/files/sshd_config
+++ b/files/sshd_config
@@ -1,3 +1,6 @@
+# Apply config from sub-files. Values in sub-files generally overrides values here.
+Include /etc/ssh/sshd_config.d/*.conf
+
 # Secure defaults
 # See: https://stribika.github.io/2015/01/04/secure-secure-shell.html
 Protocol 2


### PR DESCRIPTION
## Before

Previously, the atmoz/sftp docker image had an empty directory at `/etc/ssh/sshd_config.d/`, which I thought I could add configuration to and have it applied to sshd.  (This is a common pattern for unix services).

However, the default sshd_config file included in this project does not include those subfiles, so any config files added there are not respected.

## After
Now with this change, files added in this directory are applied.

### Example
For example, adding a file at `/etc/ssh/sshd_config.d/ancient_kex_algorithm.conf` with contents like this:
```
## Force usage of only an ancient insecure key exchange algorithms. Some of our customers have old
## opensshd servers that use kex algorithms that are no longer enabled by default. In order to test
## compatibility with those servers, we must apply this insecure config and run an integration test that
## validates we can still connect to it when the client is configured appropriately.

# Valid values documented at https://man.openbsd.org/sshd_config.5#KexAlgorithms
# No '+' in front of the name means that we override the list to just this value. Don't append.
KexAlgorithms diffie-hellman-group1-sha1
```

now allows me to test an insecure KexAlgorithms mode.

It's better to do this with one file, vs store a copy of `sshd_config` with my tweaks, so that I can pick up any future changes to the `sshd_config` file coming from this repo.