### PR TITLE
modify /home to corrent permissions while it may be mounted with wrong permissions

### DIFF
--- a/files/entrypoint
+++ b/files/entrypoint
@@ -55,6 +55,11 @@ if [ ! -f "$userConfFinalPath" ]; then
 
     # Check that we have users in config
     if [ -f "$userConfFinalPath" ] && [ "$(wc -l < "$userConfFinalPath")" -gt 0 ]; then
+        if [ -n "$(find /home -perm /go=w -o \! -user root -maxdepth 0)" ]; then
+            log "Modify /home to have the correct permissions, as it may be mounted with the wrong permissions."
+            chmod go-w /home
+            chown root /home
+        fi
         # Import users from final conf file
         while IFS= read -r user || [[ -n "$user" ]]; do
             create-sftp-user "$user"


### PR DESCRIPTION
The PR fixed `bad ownership or modes for chroot directory component "/home/"` issue while mount `/home` with wrong permissions, its modify `/home` permissions to correct automatically. It useful for deploy with mount pv in k8s, without any init settings.