### PR TITLE
Change generate encrypted passwords cmd because python update ( deprecated crypt ).

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ docker run \
 
 Tip: you can use this Python code to generate encrypted passwords:  
 `docker run --rm python:3.10 python -c "import crypt; print(crypt.crypt('YOUR_PASSWORD'))"`
+ 
 or use [makepassd](https://manpages.debian.org/bookworm/makepasswd/makepasswd.1.en.html)
+ 
 `docker run --rm --entrypoint=/usr/bin/mkpasswd atmoz/sftp:alpine "YOUR_PASSWORD"`
 
 ## Logging in with SSH keys

--- a/README.md
+++ b/README.md
@@ -97,7 +97,9 @@ docker run \
 ```
 
 Tip: you can use this Python code to generate encrypted passwords:  
-`docker run --rm python:alpine python -c "import crypt; print(crypt.crypt('YOUR_PASSWORD'))"`
+`docker run --rm python:3.10 python -c "import crypt; print(crypt.crypt('YOUR_PASSWORD'))"`
+or use [makepassd](https://manpages.debian.org/bookworm/makepasswd/makepasswd.1.en.html)
+`docker run --rm --entrypoint=/usr/bin/mkpasswd atmoz/sftp:alpine "YOUR_PASSWORD"`
 
 ## Logging in with SSH keys
 


### PR DESCRIPTION
python deprecated crypt modules in 3.11 and remove it in 3.13.
https://peps.python.org/pep-0594/#crypt